### PR TITLE
python-libarchive-c 4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set pypi = "libarchive-c" %}
 {% set name = "python-libarchive-c" %}
-{% set version = "2.9" %}
-{% set sha256 = "9919344cec203f5db6596a29b5bc26b07ba9662925a05e24980b84709232ef60" %}
+{% set version = "4.0" %}
+{% set sha256 = "a5b41ade94ba58b198d778e68000f6b7de41da768de7140c984f71d7fa8416e5" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Update python-libarchive-c to 4.0