### PR TITLE
python-libarchive-c 5.1

### DIFF
--- a/recipe/delete_unicode_files.py
+++ b/recipe/delete_unicode_files.py
@@ -1,0 +1,15 @@
+# Delete some files in this package's test data that have Unicode names, which
+# cause problems for older versions of Mamba and possibly other archiving tools.
+# We do this with this short Python script because naming the files in Unicode
+# in `meta.yaml` in turn causes problems for conda-build on Windows.
+
+import os.path
+
+testdir = os.path.join(os.environ["SRC_DIR"], "tests", "data")
+
+for fname in os.listdir(testdir):
+    if not fname.isascii():
+        ffull = os.path.join(testdir, fname)
+        # On Windows we can't even print these names safely!
+        print("- Unlinking", ffull.encode("ascii", errors="replace"))
+        os.unlink(ffull)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ test:
     - python -c "import libarchive; libarchive.extract_file('test\\hello_world.xar')"  # [win]
     - python -c "import os, shutil, libarchive; shutil.copytree(os.path.dirname(libarchive.__file__), 'libarchive')"  # [unix]
     - pytest -vv --cov libarchive --cov-report term-missing:skip-covered --cov-fail-under=83 -k "not unicode_entries"  # [linux]
-    - pytest -vv --cov libarchive -k "not (test_fd or test_files or test_buffers or atime_ctime or custom_writer or unicode_entries or test_entry)"  # [osx]
+    - pytest -vv --cov libarchive -k "not (test_fd or test_files or test_buffers or atime_ctime or custom_writer or unicode_entries)"  # [osx]
 
 about:
   home: https://github.com/Changaco/python-libarchive-c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,13 +35,14 @@ test:
   imports:
     - libarchive
   requires:
+    - mock
     - pytest-cov
   commands:
     - python -c "import libarchive; libarchive.extract_file('test/hello_world.xar')"  # [not win]
     - python -c "import libarchive; libarchive.extract_file('test\\hello_world.xar')"  # [win]
     - python -c "import os, shutil, libarchive; shutil.copytree(os.path.dirname(libarchive.__file__), 'libarchive')"  # [unix]
     - pytest -vv --cov libarchive --cov-report term-missing:skip-covered --cov-fail-under=83 -k "not unicode_entries"  # [linux]
-    - pytest -vv libarchive -k "not (test_fd or test_files or test_buffers or atime_ctime or custom_writer or unicode_entries)"  # [osx]
+    - pytest -vv --cov libarchive -k "not (test_fd or test_files or test_buffers or atime_ctime or custom_writer or unicode_entries or test_entry)"  # [osx]
 
 about:
   home: https://github.com/Changaco/python-libarchive-c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - 0002-prefer-to-load-libarchive-from-conda-pkg-path.patch
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script:
     - rd /s /q tests  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ test:
     - python -c "import libarchive; libarchive.extract_file('test/hello_world.xar')"  # [not win]
     - python -c "import libarchive; libarchive.extract_file('test\\hello_world.xar')"  # [win]
     - python -c "import os, shutil, libarchive; shutil.copytree(os.path.dirname(libarchive.__file__), 'libarchive')"  # [unix]
-    - pytest -vv libarchive -k "not unicode_entries"  # [linux]
+    - pytest -vv --cov libarchive --cov-report term-missing:skip-covered --cov-fail-under=83 -k "not unicode_entries"  # [linux]
     - pytest -vv --cov libarchive -k "not (test_fd or test_files or test_buffers or atime_ctime or custom_writer or unicode_entries)"  # [osx]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,8 +41,8 @@ test:
     - python -c "import libarchive; libarchive.extract_file('test/hello_world.xar')"  # [not win]
     - python -c "import libarchive; libarchive.extract_file('test\\hello_world.xar')"  # [win]
     - python -c "import os, shutil, libarchive; shutil.copytree(os.path.dirname(libarchive.__file__), 'libarchive')"  # [unix]
-    - pytest --cov libarchive -vv  # [linux]
-    - pytest --cov libarchive -vv -k "not test_fd and not test_files and not test_buffers"  # [osx]
+    - pytest -vv --cov libarchive --cov-report term-missing:skip-covered --cov-fail-under=83 -k "not unicode_entries"  # [linux]
+    - pytest -vv --cov libarchive -k "not (test_fd or test_files or test_buffers or atime_ctime or custom_writer or unicode_entries)"  # [osx]
 
 about:
   home: https://github.com/Changaco/python-libarchive-c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38]
+  noarch: python
   script:
     - rd /s /q tests  # [win]
     - "{{ PYTHON }} -m pip install . -vv"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set pypi = "libarchive-c" %}
 {% set name = "python-libarchive-c" %}
-{% set version = "2.9" %}
-{% set sha256 = "9919344cec203f5db6596a29b5bc26b07ba9662925a05e24980b84709232ef60" %}
+{% set version = "5.1" %}
+{% set sha256 = "7bcce24ea6c0fa3bc62468476c6d2f6264156db2f04878a372027c10615a2721" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ test:
     - python -c "import libarchive; libarchive.extract_file('test/hello_world.xar')"  # [not win]
     - python -c "import libarchive; libarchive.extract_file('test\\hello_world.xar')"  # [win]
     - python -c "import os, shutil, libarchive; shutil.copytree(os.path.dirname(libarchive.__file__), 'libarchive')"  # [unix]
-    - pytest -vv --cov libarchive --cov-report term-missing:skip-covered --cov-fail-under=83 -k "not unicode_entries"  # [linux]
+    - pytest -vv libarchive -k "not unicode_entries"  # [linux]
     - pytest -vv --cov libarchive -k "not (test_fd or test_files or test_buffers or atime_ctime or custom_writer or unicode_entries)"  # [osx]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ test:
     - python -c "import libarchive; libarchive.extract_file('test\\hello_world.xar')"  # [win]
     - python -c "import os, shutil, libarchive; shutil.copytree(os.path.dirname(libarchive.__file__), 'libarchive')"  # [unix]
     - pytest -vv --cov libarchive --cov-report term-missing:skip-covered --cov-fail-under=83 -k "not unicode_entries"  # [linux]
-    - pytest -vv --cov libarchive -k "not (test_fd or test_files or test_buffers or atime_ctime or custom_writer or unicode_entries)"  # [osx]
+    - pytest -vv libarchive -k "not (test_fd or test_files or test_buffers or atime_ctime or custom_writer or unicode_entries)"  # [osx]
 
 about:
   home: https://github.com/Changaco/python-libarchive-c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,10 +15,15 @@ build:
   number: 0
   noarch: python
   script:
-    - rd /s /q tests  # [win]
-    - "{{ PYTHON }} -m pip install . -vv"
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    # https://github.com/conda-forge/python-libarchive-c-feedstock/issues/35
+    - cd {{ RECIPE_DIR }}
+    - {{ PYTHON }} delete_unicode_files.py
+  skip: true  # [py<38]
 
 requirements:
+  build:
+    - python
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,6 @@ test:
   imports:
     - libarchive
   requires:
-    - mock
     - pytest-cov
   commands:
     - python -c "import libarchive; libarchive.extract_file('test/hello_world.xar')"  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,35 +10,15 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ pypi[0] }}/{{ pypi }}/{{ pypi }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
-  patches:
-    #
-    # I (Ray) do not think this patch should be applied. The thing it addresses should have been long fixed by:
-    # https://github.com/AnacondaRecipes/python-libarchive-c-feedstock/blob/master/recipe/0002-prefer-to-load-libarchive-from-conda-pkg-path.patch
-    # .. and if it is not, then that is what needs fixing. If libarchive fails to load due to issues in ctype's find_library
-    #    then this issue that people reported can only be considered a knock-on of the real bug.
-    #
-    # I have tested the above python patch in the face of homebrew, and the only way I can get it to break
-    # is by forcibly setting the `LIBARCHIVE` env. var to homebrew's dylib. Also, Apple have a system libarchive
-    # and I verified also that that does not get loaded.
-    # For reference, to see what dylibs python has loaded on macOS, you can use this shell code:
-    #
-    # lsof -p $(ps aux | grep python | sort | head -1 | tr -s " " | cut -f2 -d' ') |  \
-    #     grep "\.so\|.dylib" | tr -s " " | cut -f9 -d' ' | sort | xargs md5 |  \
-    #     sed -E 's|(MD5 \()([0-9a-zA-Z/.+\_-]*)\) = ([0-9a-f]*)|\3 \2|g' | sort
-    # Applying for now though:
-    - 0002-prefer-to-load-libarchive-from-conda-pkg-path.patch
 
 build:
-  number: 2
-  noarch: python
+  number: 0
+  skip: True  # [py<38]
   script:
     - rd /s /q tests  # [win]
     - "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
-  build:
-    - m2-patch                    # [win]
-    - patch                       # [not win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ test:
     - mock
     - pytest-cov
   commands:
+    - export LC_ALL=en_US.UTF-8  # [osx]
     - python -c "import libarchive; libarchive.extract_file('test/hello_world.xar')"  # [not win]
     - python -c "import libarchive; libarchive.extract_file('test\\hello_world.xar')"  # [win]
     - python -c "import os, shutil, libarchive; shutil.copytree(os.path.dirname(libarchive.__file__), 'libarchive')"  # [unix]


### PR DESCRIPTION
**Destination channel:** defaults
### Links

- [PKG-5519](https://anaconda.atlassian.net/browse/PKG-5519)
- [Upstream repository](https://github.com/Changaco/python-libarchive-c/tree/5.1)
- [Upstream changelog/diff](https://github.com/Changaco/python-libarchive-c/releases)

### Explanation of changes:

- For new `libarchive`
- Update and clean recipe
- Linter fixes
- Add LC_ALL to fix `osx` error
- Add `delete_unicode_files.py`


[PKG-5519]: https://anaconda.atlassian.net/browse/PKG-5519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ